### PR TITLE
out of bounds access query should return an empty png

### DIFF
--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -126,6 +126,12 @@ export const serve_data = {
               }
             } else {
               if (data == null) {
+                if (format === 'png') {
+                  const headers = { 'Content-Type': 'image/png' };
+                  headers['Content-Encoding'] = 'gzip';
+                  res.set(headers);
+                  return res.status(200).send(EMPTY_PNG_TILE_256);
+                }
                 return res.status(404).send('Not found');
               } else {
                 if (tileJSONFormat === 'pbf') {

--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -58,6 +58,12 @@ export const serve_data = {
           x >= Math.pow(2, z) ||
           y >= Math.pow(2, z)
         ) {
+          if (format === 'png') {
+            const headers = { 'Content-Type': 'image/png' };
+            headers['Content-Encoding'] = 'gzip';
+            res.set(headers);
+            return res.status(200).send(EMPTY_PNG_TILE_256);
+          }
           return res.status(404).send('Out of bounds');
         }
         if (item.sourceType === 'pmtiles') {


### PR DESCRIPTION
`tileserver-gl` records a 3D bounding cube where data _may_ be available in each `mbtiles` file (min_x, max_x, min_y, max_y, min_zoom, max_zoom). There are three failure scenarios:

1. If a tile request is outside of this bounding cube, then a 404 is returned. 
2. If a tile request is inside this bounding cube, the tile exists (row in sqlite db), but the tile has no image data (data is NULL), then a 404 is returned.
3. If a tile request is inside this bounding cube, but the the tile is _missing_, then a HTTP 204 response is returned. This is a particular issue for mapboxgl-js 1.X clients that treat this zero-byte response as an image and try to parse it. 

Scenario 3 was already handled in our fork, returning a transparent PNG tile. This PR handles both Scenario 1 and Scenario 2 and returns transparent PNG tiles for them as well.