### PR TITLE
Change 404 Requests to Transparent PNG Images

### DIFF
--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -126,6 +126,12 @@ export const serve_data = {
               }
             } else {
               if (data == null) {
+                if (format === 'png') {
+                  const headers = { 'Content-Type': 'image/png' };
+                  headers['Content-Encoding'] = 'gzip';
+                  res.set(headers);
+                  return res.status(200).send(EMPTY_PNG_TILE_256);
+                }
                 return res.status(404).send('Not found');
               } else {
                 if (tileJSONFormat === 'pbf') {

--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -58,6 +58,12 @@ export const serve_data = {
           x >= Math.pow(2, z) ||
           y >= Math.pow(2, z)
         ) {
+          if (format === 'png') {
+            const headers = { 'Content-Type': 'image/png' };
+            headers['Content-Encoding'] = 'gzip';
+            res.set(headers);
+            return res.status(200).send(EMPTY_PNG_TILE_256);
+          }
           return res.status(404).send('Out of bounds');
         }
         if (item.sourceType === 'pmtiles') {


### PR DESCRIPTION
I incorrectly based the [previous pull request](https://github.com/ridewithgps/tileserver-gl/pull/1) off of `master`, while we are actually using the branch `rwgps` for our work.  This pull request correctly bases off of the `rwgps` branch. It has the exact same code as before.

  