### PR TITLE
Serve encoding/size-matched blank tiles for missing DEM tiles

### DIFF
--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -20,18 +20,45 @@ import { gunzipP, gzipP } from './promises.js';
 import { openMbTilesWrapper } from './mbtiles_wrapper.js';
 
 import fs from 'node:fs';
-import zlib from 'node:zlib';
+import sharp from 'sharp';
 import { fileURLToPath } from 'url';
 
-// Pre-computed 256x256 PNG with every pixel set to RGB(1, 134, 160) — Mapbox
-// Terrain-RGB encoding for 0m elevation (sea level). Served for missing
-// elevation tiles so MapLibre raster-dem sources don't choke on 404 or 204.
-const BLANK_TERRAIN_TILE = zlib.gzipSync(
-  Buffer.from(
-    'iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAAB/UlEQVR42u3TQREAAAQAQYSXQ1RvGexGuJnL7An4qiTAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAGAAMAAYAA4ABwABgADAAGAAMAAYAA4ABwABgADAAGAAMAAYAA4ABwABgADAAGAAMAAYAA4ABwABgADAAGAAMAAYAA4ABwABgADAAGAAMAAYAA4ABwABgADAAGAAMAAbAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGgGsBhjkDJzJVFysAAAAASUVORK5CYII=',
-    'base64',
-  ),
-);
+// Sea-level (0 m) RGB for each terrain-RGB encoding, i.e. the value that
+// decodes to 0 m: mapbox = -10000 + (R*65536+G*256+B)*0.1, terrarium =
+// R*256 + G + B/256 - 32768.
+const TERRAIN_SEA_LEVEL_RGB = {
+  mapbox: { r: 1, g: 134, b: 160 },
+  terrarium: { r: 128, g: 0, b: 0 },
+};
+
+const blankTerrainTileCache = {};
+
+/**
+ * Builds (and caches) a gzipped PNG of `tileSize`×`tileSize` filled with the
+ * sea-level color for `encoding`. Served for missing elevation tiles so a
+ * raster-dem source's tiles all share the same dimensions — MapLibre throws
+ * "dem dimension mismatch" when a tile borders a neighbor of a different size.
+ * @param {string} encoding - 'mapbox' or 'terrarium'.
+ * @param {number} tileSize - Tile width/height in pixels.
+ * @returns {Promise<Buffer>} Gzipped PNG.
+ */
+async function getBlankTerrainTile(encoding, tileSize) {
+  const key = `${encoding}:${tileSize}`;
+  if (!blankTerrainTileCache[key]) {
+    const png = await sharp({
+      create: {
+        width: tileSize,
+        height: tileSize,
+        channels: 3,
+        background: TERRAIN_SEA_LEVEL_RGB[encoding],
+      },
+    })
+      .png()
+      .toBuffer();
+    blankTerrainTileCache[key] = await gzipP(png);
+  }
+  return blankTerrainTileCache[key];
+}
 
 const packageJson = JSON.parse(
   fs.readFileSync(
@@ -120,12 +147,17 @@ export const serve_data = {
         y,
       );
       if (fetchTile == null) {
-        if (item.tileJSON.encoding === 'mapbox') {
+        const { encoding } = item.tileJSON;
+        if (encoding === 'mapbox' || encoding === 'terrarium') {
+          const tileSize =
+            item.tileJSON.tileSize || (encoding === 'terrarium' ? 512 : 256);
           res.set({
             'Content-Type': 'image/png',
             'Content-Encoding': 'gzip',
           });
-          return res.status(200).send(BLANK_TERRAIN_TILE);
+          return res
+            .status(200)
+            .send(await getBlankTerrainTile(encoding, tileSize));
         }
         return res.status(204).send();
       }

--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -14,6 +14,7 @@ import {
   getTileUrls,
   isValidHttpUrl,
   fetchTileData,
+  projectToTilePixel,
 } from './utils.js';
 import { getPMtilesInfo, openPMtiles } from './pmtiles_adapter.js';
 import { gunzipP, gzipP } from './promises.js';
@@ -297,9 +298,11 @@ export const serve_data = {
           if (zoom > tileJSON.maxzoom) {
             zoom = tileJSON.maxzoom;
           }
-          bbox = [x, y, x + 0.1, y + 0.1];
-          const { minX, minY } = new SphericalMercator().xyz(bbox, zoom);
-          xy = [minX, minY];
+          bbox = [x, y, x, y];
+          // Same projection as getTerrainElevation so the fetched tile matches
+          // the sampled pixel.
+          const { xTile, yTile } = projectToTilePixel(x, y, zoom, TILE_SIZE);
+          xy = [xTile, yTile];
         }
 
         const fetchTile = await fetchTileData(

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -34,6 +34,7 @@ import {
   fixTileJSONCenter,
   fetchTileData,
   readFile,
+  projectToTilePixel,
 } from './utils.js';
 import { openPMtiles, getPMtilesInfo } from './pmtiles_adapter.js';
 import { renderOverlay, renderWatermark, renderAttribution } from './render.js';
@@ -1642,24 +1643,12 @@ export const serve_rendered = {
         const context = canvas.getContext('2d');
         context.drawImage(image, 0, 0);
 
-        // calculate pixel coordinate of tile,
-        // see https://developers.google.com/maps/documentation/javascript/examples/map-coordinates
-        let siny = Math.sin((param['lat'] * Math.PI) / 180);
-        // Truncating to 0.9999 effectively limits latitude to 89.189. This is
-        // about a third of a tile past the edge of the world tile.
-        siny = Math.min(Math.max(siny, -0.9999), 0.9999);
-        const xWorld = param['tile_size'] * (0.5 + param['long'] / 360);
-        const yWorld =
-          param['tile_size'] *
-          (0.5 - Math.log((1 + siny) / (1 - siny)) / (4 * Math.PI));
-
-        const scale = 1 << param['z'];
-
-        const xTile = Math.floor((xWorld * scale) / param['tile_size']);
-        const yTile = Math.floor((yWorld * scale) / param['tile_size']);
-
-        const xPixel = Math.floor(xWorld * scale) - xTile * param['tile_size'];
-        const yPixel = Math.floor(yWorld * scale) - yTile * param['tile_size'];
+        const { xPixel, yPixel } = projectToTilePixel(
+          param['long'],
+          param['lat'],
+          param['z'],
+          param['tile_size'],
+        );
         if (
           xPixel < 0 ||
           yPixel < 0 ||

--- a/src/utils.js
+++ b/src/utils.js
@@ -231,6 +231,35 @@ export function fixTileJSONCenter(tileJSON) {
 }
 
 /**
+ * Projects a geographic coordinate to its enclosing tile and the pixel within
+ * that tile, using the Web-Mercator world-pixel formula.
+ * See https://developers.google.com/maps/documentation/javascript/examples/map-coordinates
+ * @param {number} lon - Longitude in degrees.
+ * @param {number} lat - Latitude in degrees.
+ * @param {number} zoom - Tile zoom level.
+ * @param {number} tileSize - Tile size in pixels (e.g. 256 or 512).
+ * @returns {{xTile: number, yTile: number, xPixel: number, yPixel: number}}
+ */
+export function projectToTilePixel(lon, lat, zoom, tileSize) {
+  let siny = Math.sin((lat * Math.PI) / 180);
+  // Truncating to 0.9999 effectively limits latitude to 89.189. This is
+  // about a third of a tile past the edge of the world tile.
+  siny = Math.min(Math.max(siny, -0.9999), 0.9999);
+  const xWorld = tileSize * (0.5 + lon / 360);
+  const yWorld =
+    tileSize * (0.5 - Math.log((1 + siny) / (1 - siny)) / (4 * Math.PI));
+  const scale = 1 << zoom;
+  const xTile = Math.floor((xWorld * scale) / tileSize);
+  const yTile = Math.floor((yWorld * scale) / tileSize);
+  return {
+    xTile,
+    yTile,
+    xPixel: Math.floor(xWorld * scale) - xTile * tileSize,
+    yPixel: Math.floor(yWorld * scale) - yTile * tileSize,
+  };
+}
+
+/**
  * Reads a file and returns a Promise with the file data.
  * @param {string} filename - Path to the file to read.
  * @returns {Promise<Buffer>} - A Promise that resolves with the file data as a Buffer or rejects with an error.

--- a/test/elevation_tile_selection.js
+++ b/test/elevation_tile_selection.js
@@ -1,0 +1,17 @@
+import { projectToTilePixel } from '../src/utils.js';
+
+// The elevation route fetches the tile and getTerrainElevation samples the
+// pixel both via projectToTilePixel, so they can't disagree. Pin a known point:
+// pixel (189,206) of 12/663/1467 decodes to ~3411 m at Mt Hood's summit. An
+// earlier `[x, y, x + 0.1, y + 0.1]` box picked a tile ~2 rows north and read
+// ~1058 m instead.
+describe('Elevation query tile selection', function () {
+  it('resolves a point to the tile/pixel containing it', function () {
+    expect(projectToTilePixel(-121.6959, 45.3736, 12, 512)).to.deep.equal({
+      xTile: 663,
+      yTile: 1467,
+      xPixel: 189,
+      yPixel: 206,
+    });
+  });
+});


### PR DESCRIPTION
#### Description of work

When an elevation tile is missing, we serve a blank sea-level DEM tile so MapLibre's raster-dem parser on the client doesn't crash. That blank was hardcoded to a 256px **mapbox**-encoded PNG, which only matched our old `elevation` mbtiles source.

With the Mapterhorn **terrarium** sources (512px), a wrong-sized/wrong-encoding blank makes the client throw `dem dimension mismatch`. This makes the blank match the source:

- **terrarium** → 512px, sea level `rgb(128,0,0)`
- **mapbox** → 256px, sea level `rgb(1,134,160)`

Size comes from the source's `tileSize` in config when set, otherwise defaults by encoding (terrarium 512, mapbox 256).

_(A second commit also fixes the point elevation-lookup endpoint — a correctness fix, but that endpoint isn't currently used.)_

#### Amount of Risk (targeted change, large change, etc)

Low / targeted — only the missing-tile fallback for elevation sources.

#### Level of QA Needed (local, staged, staged and formal QA needed)

Local.

#### Test Plan
- [x] A missing terrarium tile returns a 512×512 blank that decodes to 0 m
- [x] Client hillshade over Mapterhorn no longer throws `dem dimension mismatch`

#### Release

No version bump (the `-rwgpsN` suffix lives only in the git tag, not `package.json`).

1. Merge this PR into `master`.
2. Create the release/tag `v5.3.0-rwgps1` on `master` (previous is `v5.3.0-rwgps0`).
3. The `build_container` Jenkins job auto-builds and pushes `registry.ridewithgps.com/rwgps/tileserver-gl:v5.3.0-rwgps1`.
